### PR TITLE
[DO NOT LAND] analyze issue 175865 "torch.export.load holds GIL during tensor deserialization, preventing parallel loading"

### DIFF
--- a/analysis.md
+++ b/analysis.md
@@ -1,0 +1,11 @@
+# Analysis for Issue #175865: torch.export.load holds GIL during tensor deserialization, preventing parallel loading
+
+**Issue**: https://github.com/pytorch/pytorch/issues/175865
+**Category**: confirmed_bug
+**Summary**: torch.export.load holds the GIL during tensor deserialization via get_record, preventing parallel loading. The get_record C++ binding lacks a gil_scoped_release and returns py::bytes (double copy), while get_storage_from_record already returns tensors directly.
+
+**CC**: @angelayi
+
+## Fix Description
+
+Two changes: (1) C++ side (init.cpp): Release the GIL during the zip read in the get_record binding using py::gil_scoped_release, and add a new get_record_as_tensor binding that reads a record and returns a uint8 tensor directly (zero-copy from the C++ DataPtr, no py::bytes intermediate). (2) Python side (_package.py): Add a read_tensor method to PT2ArchiveReader that calls get_record_as_tensor and views the result as the target dtype. Update _build_file_map to use read_tensor instead of read_bytes, eliminating the double copy (file -> C++ buffer -> Python bytes -> tensor) and allowing the GIL to be released during I/O. This matches the torch.load path which achieves near-linear thread scaling.

--- a/result.json
+++ b/result.json
@@ -1,0 +1,14 @@
+{
+  "category": "confirmed_bug",
+  "summary": "torch.export.load holds the GIL during tensor deserialization via get_record, preventing parallel loading. The get_record C++ binding lacks a gil_scoped_release and returns py::bytes (double copy), while get_storage_from_record already returns tensors directly.",
+  "answer": null,
+  "repro_code": null,
+  "repro_output": null,
+  "commit_hash": "03af6e5b3ebe1c62b4e1d29529325339385e9c02",
+  "fix_description": "Two changes: (1) C++ side (init.cpp): Release the GIL during the zip read in the get_record binding using py::gil_scoped_release, and add a new get_record_as_tensor binding that reads a record and returns a uint8 tensor directly (zero-copy from the C++ DataPtr, no py::bytes intermediate). (2) Python side (_package.py): Add a read_tensor method to PT2ArchiveReader that calls get_record_as_tensor and views the result as the target dtype. Update _build_file_map to use read_tensor instead of read_bytes, eliminating the double copy (file -> C++ buffer -> Python bytes -> tensor) and allowing the GIL to be released during I/O. This matches the torch.load path which achieves near-linear thread scaling.",
+  "patch_file": "fix.patch",
+  "existing_pr": null,
+  "cc": [
+    "angelayi"
+  ]
+}

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1599,8 +1599,35 @@ void initJITBindings(PyObject* module) {
       .def(
           "get_record",
           [](PyTorchStreamReader& self, const std::string& key) {
-            auto [data, size] = self.getRecord(key);
+            at::DataPtr data;
+            size_t size;
+            {
+              py::gil_scoped_release release;
+              std::tie(data, size) = self.getRecord(key);
+            }
             return py::bytes(reinterpret_cast<const char*>(data.get()), size);
+          })
+      .def(
+          "get_record_as_tensor",
+          [](PyTorchStreamReader& self, const std::string& key) {
+            at::DataPtr data;
+            size_t size;
+            {
+              py::gil_scoped_release release;
+              std::tie(data, size) = self.getRecord(key);
+            }
+            c10::Storage storage(
+                c10::Storage::use_byte_size_t(),
+                size,
+                std::move(data),
+                /*allocator=*/nullptr,
+                /*resizable=*/false);
+            auto ptr =
+                c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
+                    std::move(storage),
+                    at::DispatchKeySet(),
+                    at::CPU(at::kByte).typeMeta());
+            return at::Tensor(std::move(ptr));
           })
       .def(
           "has_record",

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -214,6 +214,14 @@ class PT2ArchiveReader:
         """
         return self.archive_file.get_record(name)
 
+    def read_tensor(self, name: str, dtype: torch.dtype) -> torch.Tensor:
+        """
+        Read a record from the archive directly as a tensor, avoiding the
+        intermediate py::bytes copy. The GIL is released during the zip read.
+        """
+        raw = self.archive_file.get_record_as_tensor(name)
+        return raw.view(dtype=dtype)
+
     def read_string(self, name: str) -> str:
         """
         Read a string object from the archive.
@@ -774,26 +782,26 @@ class PT2ArchiveContents:
     extra_files: dict[str, Any]
 
 
-def _create_flat_tensor_from_bytes(
-    tensor_bytes: bytes,
+def _create_flat_tensor(
+    raw_tensor: torch.Tensor,
     tensor_meta: schema.TensorMeta,
 ) -> torch.Tensor:
     """
-    Create a flat tensor from raw bytes with dtype, device and requires_grad.
+    Create a flat tensor from a raw uint8 tensor with dtype, device and requires_grad.
     It will be re-strided based on size, stride, and storage_offset later.
     """
-    dtype = deserialize_scalar_type(tensor_meta.dtype)
     size = deserialize_size(tensor_meta.sizes)
     device = deserialize_device(tensor_meta.device)
 
-    if len(tensor_bytes) != 0:
-        tensor = torch.frombuffer(
-            tensor_bytes, dtype=dtype, requires_grad=tensor_meta.requires_grad
-        ).to(device)
+    if raw_tensor.numel() != 0:
+        tensor = raw_tensor
+        if tensor_meta.requires_grad:
+            tensor = tensor.requires_grad_(True)
+        tensor = tensor.to(device)
     else:
-        # cannot call torch.frombuffer() on empty bytes
+        dtype = deserialize_scalar_type(tensor_meta.dtype)
         logger.warning(
-            "Cannot call torch.frombuffer() on empty bytes. "
+            "Cannot create tensor from empty record. "
             "Creating a tensor with zeros as workaround."
         )
         tensor = torch.zeros(size, dtype=dtype, device=device)
@@ -818,12 +826,14 @@ def _build_file_map(
         if payload_meta.path_name in file_map:
             continue
 
-        tensor_bytes = archive_reader.read_bytes(
-            os.path.join(base_dir, payload_meta.path_name)
-        )
         if payload_meta.tensor_meta is None:
             raise AssertionError("payload_meta.tensor_meta cannot be None")
-        tensor = _create_flat_tensor_from_bytes(tensor_bytes, payload_meta.tensor_meta)
+        dtype = deserialize_scalar_type(payload_meta.tensor_meta.dtype)
+        raw_tensor = archive_reader.read_tensor(
+            os.path.join(base_dir, payload_meta.path_name),
+            dtype,
+        )
+        tensor = _create_flat_tensor(raw_tensor, payload_meta.tensor_meta)
         file_map[payload_meta.path_name] = tensor
 
     return file_map


### PR DESCRIPTION
Automated analysis for https://github.com/pytorch/pytorch/issues/175865