### PR TITLE
[DO NOT LAND] analyze issue 176428 "torch.export.load() slow due to Python-side schema deserialization"

### DIFF
--- a/analysis.md
+++ b/analysis.md
@@ -1,0 +1,7 @@
+# Analysis for Issue #176428: torch.export.load() slow due to Python-side schema deserialization
+
+**Issue**: https://github.com/pytorch/pytorch/issues/176428
+**Category**: feature_request
+**Summary**: Feature request to speed up torch.export.load() by exposing C++ schema types with pybind11 property bindings, eliminating slow Python-side JSON/dataclass deserialization
+
+**CC**: @angelayi, @tolleybot

--- a/result.json
+++ b/result.json
@@ -1,0 +1,15 @@
+{
+  "category": "feature_request",
+  "summary": "Feature request to speed up torch.export.load() by exposing C++ schema types with pybind11 property bindings, eliminating slow Python-side JSON/dataclass deserialization",
+  "answer": null,
+  "repro_code": null,
+  "repro_output": null,
+  "commit_hash": "cbc35eb2b3e31592a42fad99c1d5e86785ed832a",
+  "fix_description": null,
+  "patch_file": null,
+  "existing_pr": "https://github.com/pytorch/pytorch/pull/176434",
+  "cc": [
+    "angelayi",
+    "tolleybot"
+  ]
+}


### PR DESCRIPTION
Automated analysis for https://github.com/pytorch/pytorch/issues/176428